### PR TITLE
Le chemin du fichier pour Tron.py devien relatif

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ Ceci est le projet de 2ème session en programation.
 Il s'agit d'un jeu de type Tron Light cycle
 
 Créateur: Guillaume Hamel-Gagné
-
+Petite amélioration: Olivier Bombardier

--- a/start.bat
+++ b/start.bat
@@ -1,2 +1,2 @@
-c:\python34\python.exe C:\Users\Guillaume\OneDrive\Documents\Travail_Avancer\Tron.py
+c:\python34\python.exe Tron.py
 pause


### PR DESCRIPTION
Le chemin du fichier pour Tron.py dans start.bat devien relatif au lieu d'absolu afin de fonctioner sur d'autres ordinateurs.
